### PR TITLE
Updated scripts simplify_data default.

### DIFF
--- a/R/ce01issm_midwater_ph_pco2_ctd.R
+++ b/R/ce01issm_midwater_ph_pco2_ctd.R
@@ -110,15 +110,15 @@ CTD_files = ooi_download_data(CTD_opendap,directory = CTD_path)
 
 
 #Bring data into the workspace.
-pH_lol = ooi_get_data(pH_files,simplify_data= TRUE)  #Merge data from multiple NetCDFs and drop data products that are confusing or generally useless.
+pH_lol = ooi_get_data(pH_files,simplify_data= FALSE)  #Merge data from multiple NetCDFs and drop data products that are confusing or generally useless.
 pH_data = data.frame(pH_lol[['data']])  #The first list of the ooi_get_data return is always the data.
 pH_vars = data.frame(pH_lol[['variables_units']]) #The second list of the ooi_get_data return is always a list of variables and units.
 
-pCO2_lol = ooi_get_data(pCO2_files,simplify_data = TRUE)
+pCO2_lol = ooi_get_data(pCO2_files,simplify_data = FALSE)
 pCO2_data = data.frame(pCO2_lol[['data']])
 pCO2_vars = data.frame(pCO2_lol[['variables_units']])
 
-CTD_lol = ooi_get_data(CTD_files,simplify_data = TRUE)
+CTD_lol = ooi_get_data(CTD_files,simplify_data = FALSE)
 CTD_data = data.frame(CTD_lol[['data']])
 CTD_vars = data.frame(CTD_lol[['variables_units']])
 

--- a/R/ce02shsm_midwater_fluorometer.R
+++ b/R/ce02shsm_midwater_fluorometer.R
@@ -32,7 +32,7 @@ method = 'recovered_host'
 start_date = '2019-06-01'
 stop_date = '2019-06-30'
 drop_paired = TRUE
-simplify_data = TRUE
+simplify_data = FALSE
 ###---------------------------------###
 
 

--- a/R/ce02shsp_profiler_do.R
+++ b/R/ce02shsp_profiler_do.R
@@ -30,7 +30,7 @@ method = 'recovered_cspp'
 start_date = '2019-01-01'
 stop_date = '2019-12-31'
 drop_paired = TRUE
-simplify_data = TRUE
+simplify_data = FALSE
 ####---------------------------------###
 
 
@@ -48,7 +48,7 @@ data = data.frame(lol[['data']]) #Organize the data so it is easier on the eyes.
 varunits = data.frame(lol[['variables_units']])  #Offers a table of the variables and associated units.
 
 data$time = as.POSIXct(data$profiler_timestamp,tz='UTC',origin='1970-01-01')  #Convert time to something understandable. profiler_timestamp is a common value among CSPP sensors.
-data = data[(data$pressure_depth<max_depth & data$pressure_depth>min_depth),]  #Only keep values that are between the max and min depth determined through the ooi_site_depth() function.
+data = data[(data$pressure<max_depth & data$pressure>min_depth),]  #Only keep values that are between the max and min depth determined through the ooi_site_depth() function.
 
 
 #-------------------------------------#
@@ -59,7 +59,7 @@ myPalette <- colorRampPalette(rev(brewer.pal(11, "Spectral")))
 sc <- scale_colour_gradientn(colours = myPalette(100), limits=c(0, 300))
 
 
-oxy_plot = ggplot(data,aes(time,pressure_depth,colour = dissolved_oxygen)) +
+oxy_plot = ggplot(data,aes(time,pressure,colour = dissolved_oxygen)) +
   geom_point() +
   scale_y_reverse() +
   sc +

--- a/R/cp04ossm_surface_wind.R
+++ b/R/cp04ossm_surface_wind.R
@@ -29,7 +29,7 @@ stream = "metbk_a_dcl_instrument"
 start_date = '2019-06-01'
 stop_date = '2019-06-01'
 drop_paired = TRUE
-simplify_data = TRUE
+simplify_data = FALSE
 ###---------------------------------###
 
 

--- a/R/gio3flma_riser_ctds.R
+++ b/R/gio3flma_riser_ctds.R
@@ -80,7 +80,7 @@ files = data.frame(files)  #Put the filenames into a data.frame.
 data = list()
 for (id in ctd_id){  #For each CTD id.
   ctd <- toString(files[grep(id, files[, "files"]),])  #Identify which files have data for that CTD.
-  hold =  ooi_get_data(ctd,simplify_data = TRUE)
+  hold =  ooi_get_data(ctd,simplify_data = FALSE)
   data[id] = list(hold)  #Bring that data into the workspace so that we get a list of lists of data.
 }
 


### PR DESCRIPTION
With the transition to "pressure" from "pressure_depth", there are discrepancies in variables found in netcdfs and variables identified via 12576/stream (which is what the ooi_science.rda file is generated from). Until this is resolved, users should use FALSE as the simplify_data flag. This will pull all variables from the netcdf. Users will still have to identify which variables they want to use.