### PR TITLE
 Adding a DOSTA Processor, Harvester and Example Methods 

### DIFF
--- a/python/examples/dosta/recovered_host_ctdbp_dosta.py
+++ b/python/examples/dosta/recovered_host_ctdbp_dosta.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from ooi_data_explorations.common import list_deployments, get_deployment_dates, get_vocabulary, m2m_request, \
+    m2m_collect, update_dataset, CONFIG, ENCODINGS
+from ooi_data_explorations.uncabled.process_dosta import dosta_ctdbp_datalogger
+
+
+def main():
+    # Setup needed parameters for the request, the user would need to vary these to suit their own needs and
+    # sites/instruments of interest. Site, node, sensor, stream and delivery method names can be obtained from the
+    # Ocean Observatories Initiative web site. The last two will set path and naming conventions to save the data
+    # to the local disk
+    site = 'CE01ISSM'           # OOI Net site designator
+    node = 'RID16'              # OOI Net node designator
+    sensor = '03-DOSTAD000'     # OOI Net sensor designator
+    stream = 'dosta_abcdjm_ctdbp_dcl_instrument_recovered'  # OOI Net stream name
+    method = 'recovered_host'   # OOI Net data delivery method
+    level = 'nsif'              # local directory name, level below site
+    instrmt = 'dosta'           # local directory name, instrument below level
+
+    # We are after recovered host data. Determine list of deployments and use the one 2 back from the most recent
+    # (presumably currently active) deployment to determine the start and end dates for our request.
+    vocab = get_vocabulary(site, node, sensor)[0]
+    deployments = list_deployments(site, node, sensor)
+    deploy = deployments[-3]
+    start, stop = get_deployment_dates(site, node, sensor, deploy)
+
+    # request and download the data
+    r = m2m_request(site, node, sensor, method, stream, start, stop)
+    dosta = m2m_collect(r, '.*DOSTA.*\\.nc$')
+    dosta = dosta.where(dosta.deployment == deploy, drop=True)  # limit to the deployment of interest
+
+    # clean-up and reorganize
+    dosta = dosta_ctdbp_datalogger(dosta)
+    dosta = update_dataset(dosta, vocab['maxdepth'])
+
+    # save the data
+    out_path = os.path.join(CONFIG['base_dir']['m2m_base'], site.lower(), level, instrmt)
+    out_path = os.path.abspath(out_path)
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    out_file = ('%s.%s.%s.deploy%02d.%s.%s.nc' % (site.lower(), level, instrmt, deploy, method, stream))
+    nc_out = os.path.join(out_path, out_file)
+
+    dosta.to_netcdf(nc_out, mode='w', format='NETCDF4', engine='h5netcdf', encoding=ENCODINGS)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/examples/dosta/recovered_host_solo_dosta.py
+++ b/python/examples/dosta/recovered_host_solo_dosta.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from ooi_data_explorations.common import list_deployments, get_deployment_dates, get_vocabulary, m2m_request, \
+    m2m_collect, update_dataset, CONFIG, ENCODINGS
+from ooi_data_explorations.uncabled.process_dosta import dosta_datalogger
+
+
+def main():
+    # Setup needed parameters for the request, the user would need to vary these to suit their own needs and
+    # sites/instruments of interest. Site, node, sensor, stream and delivery method names can be obtained from the
+    # Ocean Observatories Initiative web site. The last two will set path and naming conventions to save the data
+    # to the local disk
+    site = 'CE02SHSM'           # OOI Net site designator
+    node = 'RID27'              # OOI Net node designator
+    sensor = '04-DOSTAD000'     # OOI Net sensor designator
+    stream = 'dosta_abcdjm_dcl_instrument_recovered'  # OOI Net stream name
+    method = 'recovered_host'   # OOI Net data delivery method
+    level = 'nsif'              # local directory name, level below site
+    instrmt = 'dosta'           # local directory name, instrument below level
+
+    # We are after recovered host data. Determine list of deployments and use the one 2 back from the most recent
+    # (presumably currently active) deployment to determine the start and end dates for our request.
+    vocab = get_vocabulary(site, node, sensor)[0]
+    deployments = list_deployments(site, node, sensor)
+    deploy = deployments[-3]
+    start, stop = get_deployment_dates(site, node, sensor, deploy)
+
+    # request and download the data
+    r = m2m_request(site, node, sensor, method, stream, start, stop)
+    dosta = m2m_collect(r, '.*dosta.*\\.nc$')
+    dosta = dosta.where(dosta.deployment == deploy, drop=True)  # limit to the deployment of interest
+
+    # clean-up and reorganize
+    dosta = dosta_datalogger(dosta, burst=True)
+    dosta = update_dataset(dosta, vocab['maxdepth'])
+
+    # save the data
+    out_path = os.path.join(CONFIG['base_dir']['m2m_base'], site.lower(), level, instrmt)
+    out_path = os.path.abspath(out_path)
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    out_file = ('%s.%s.%s.deploy%02d.%s.%s.nc' % (site.lower(), level, instrmt, deploy, method, stream))
+    nc_out = os.path.join(out_path, out_file)
+
+    dosta.to_netcdf(nc_out, mode='w', format='NETCDF4', engine='h5netcdf', encoding=ENCODINGS)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/examples/dosta/recovered_inst_ctdbp_dosta.py
+++ b/python/examples/dosta/recovered_inst_ctdbp_dosta.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from ooi_data_explorations.common import list_deployments, get_deployment_dates, get_vocabulary, m2m_request, \
+    m2m_collect, update_dataset, CONFIG, ENCODINGS
+from ooi_data_explorations.uncabled.process_dosta import dosta_ctdbp_instrument
+
+
+def main():
+    # Setup needed parameters for the request, the user would need to vary these to suit their own needs and
+    # sites/instruments of interest. Site, node, sensor, stream and delivery method names can be obtained from the
+    # Ocean Observatories Initiative web site. The last two will set path and naming conventions to save the data
+    # to the local disk
+    site = 'CE01ISSM'           # OOI Net site designator
+    node = 'RID16'              # OOI Net node designator
+    sensor = '03-DOSTAD000'     # OOI Net sensor designator
+    stream = 'dosta_abcdjm_ctdbp_instrument_recovered'  # OOI Net stream name
+    method = 'recovered_inst'   # OOI Net data delivery method
+    level = 'nsif'              # local directory name, level below site
+    instrmt = 'dosta'           # local directory name, instrument below level
+
+    # We are after recovered host data. Determine list of deployments and use the one 2 back from the most recent
+    # (presumably currently active) deployment to determine the start and end dates for our request.
+    vocab = get_vocabulary(site, node, sensor)[0]
+    deployments = list_deployments(site, node, sensor)
+    deploy = deployments[-3]
+    start, stop = get_deployment_dates(site, node, sensor, deploy)
+
+    # request and download the data
+    r = m2m_request(site, node, sensor, method, stream, start, stop)
+    dosta = m2m_collect(r, '.*DOSTA.*\\.nc$')
+    dosta = dosta.where(dosta.deployment == deploy, drop=True)  # limit to the deployment of interest
+
+    # clean-up and reorganize
+    dosta = dosta_ctdbp_instrument(dosta)
+    dosta = update_dataset(dosta, vocab['maxdepth'])
+
+    # save the data
+    out_path = os.path.join(CONFIG['base_dir']['m2m_base'], site.lower(), level, instrmt)
+    out_path = os.path.abspath(out_path)
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    out_file = ('%s.%s.%s.deploy%02d.%s.%s.nc' % (site.lower(), level, instrmt, deploy, method, stream))
+    nc_out = os.path.join(out_path, out_file)
+
+    dosta.to_netcdf(nc_out, mode='w', format='NETCDF4', engine='h5netcdf', encoding=ENCODINGS)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/examples/dosta/telemetered_ctdbp_dosta.py
+++ b/python/examples/dosta/telemetered_ctdbp_dosta.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from ooi_data_explorations.common import list_deployments, get_deployment_dates, get_vocabulary, m2m_request, \
+    m2m_collect, update_dataset, CONFIG, ENCODINGS
+from ooi_data_explorations.uncabled.process_dosta import dosta_ctdbp_datalogger
+
+
+def main():
+    # Setup needed parameters for the request, the user would need to vary these to suit their own needs and
+    # sites/instruments of interest. Site, node, sensor, stream and delivery method names can be obtained from the
+    # Ocean Observatories Initiative web site. The last two will set path and naming conventions to save the data
+    # to the local disk
+    site = 'CE01ISSM'           # OOI Net site designator
+    node = 'RID16'              # OOI Net node designator
+    sensor = '03-DOSTAD000'     # OOI Net sensor designator
+    stream = 'dosta_abcdjm_ctdbp_dcl_instrument'  # OOI Net stream name
+    method = 'telemetered'      # OOI Net data delivery method
+    level = 'nsif'              # local directory name, level below site
+    instrmt = 'dosta'           # local directory name, instrument below level
+
+    # We are after telemetered data. Determine list of deployments and use the last, presumably currently active,
+    # deployment to determine the start and end dates for our request.
+    vocab = get_vocabulary(site, node, sensor)[0]
+    deployments = list_deployments(site, node, sensor)
+    deploy = deployments[-1]
+    start, stop = get_deployment_dates(site, node, sensor, deploy)
+
+    # request and download the data
+    r = m2m_request(site, node, sensor, method, stream, start, stop)
+    dosta = m2m_collect(r, '.*dosta.*\\.nc$')
+    dosta = dosta.where(dosta.deployment == deploy, drop=True)  # limit to the deployment of interest
+
+    # clean-up and reorganize
+    dosta = dosta_ctdbp_datalogger(dosta)
+    dosta = update_dataset(dosta, vocab['maxdepth'])
+
+    # save the data
+    out_path = os.path.join(CONFIG['base_dir']['m2m_base'], site.lower(), level, instrmt)
+    out_path = os.path.abspath(out_path)
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    out_file = ('%s.%s.%s.deploy%02d.%s.%s.nc' % (site.lower(), level, instrmt, deploy, method, stream))
+    nc_out = os.path.join(out_path, out_file)
+
+    dosta.to_netcdf(nc_out, mode='w', format='NETCDF4', engine='h5netcdf', encoding=ENCODINGS)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/examples/dosta/telemetered_solo_dosta.py
+++ b/python/examples/dosta/telemetered_solo_dosta.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+
+from ooi_data_explorations.common import list_deployments, get_deployment_dates, get_vocabulary, m2m_request, \
+    m2m_collect, update_dataset, CONFIG, ENCODINGS
+from ooi_data_explorations.uncabled.process_dosta import dosta_datalogger
+
+
+def main():
+    # Setup needed parameters for the request, the user would need to vary these to suit their own needs and
+    # sites/instruments of interest. Site, node, sensor, stream and delivery method names can be obtained from the
+    # Ocean Observatories Initiative web site. The last two will set path and naming conventions to save the data
+    # to the local disk
+    site = 'CE02SHSM'           # OOI Net site designator
+    node = 'RID27'              # OOI Net node designator
+    sensor = '04-DOSTAD000'     # OOI Net sensor designator
+    stream = 'dosta_abcdjm_dcl_instrument'  # OOI Net stream name
+    method = 'telemetered'      # OOI Net data delivery method
+    level = 'nsif'              # local directory name, level below site
+    instrmt = 'dosta'           # local directory name, instrument below level
+
+    # We are after telemetered data. Determine list of deployments and use the last, presumably currently active,
+    # deployment to determine the start and end dates for our request.
+    vocab = get_vocabulary(site, node, sensor)[0]
+    deployments = list_deployments(site, node, sensor)
+    deploy = deployments[-1]
+    start, stop = get_deployment_dates(site, node, sensor, deploy)
+
+    # request and download the data
+    r = m2m_request(site, node, sensor, method, stream, start, stop)
+    dosta = m2m_collect(r, '.*dosta.*\\.nc$')
+    dosta = dosta.where(dosta.deployment == deploy, drop=True)  # limit to the deployment of interest
+
+    # clean-up and reorganize
+    dosta = dosta_datalogger(dosta, burst=True)
+    dosta = update_dataset(dosta, vocab['maxdepth'])
+
+    # save the data
+    out_path = os.path.join(CONFIG['base_dir']['m2m_base'], site.lower(), level, instrmt)
+    out_path = os.path.abspath(out_path)
+    if not os.path.exists(out_path):
+        os.makedirs(out_path)
+
+    out_file = ('%s.%s.%s.deploy%02d.%s.%s.nc' % (site.lower(), level, instrmt, deploy, method, stream))
+    nc_out = os.path.join(out_path, out_file)
+
+    dosta.to_netcdf(nc_out, mode='w', format='NETCDF4', engine='h5netcdf', encoding=ENCODINGS)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/ooi_data_explorations/common.py
+++ b/python/ooi_data_explorations/common.py
@@ -520,6 +520,14 @@ def process_file(catalog_file):
     if not ds:
         return None
 
+    # address error in how the *_qartod_executed variables are set
+    qartod_pattern = re.compile(r'^.+_qartod_executed.+$')
+    for v in ds.variables:
+        if qartod_pattern.match(v):
+            # the shape of the QARTOD executed should compare to the provenance variable
+            if ds[v].shape[0] != ds['provenance'].shape[0]:
+                ds = ds.drop_vars(v)
+
     ds = ds.swap_dims({'obs': 'time'})
     ds = ds.reset_coords()
     keys = ['obs', 'id', 'provenance', 'driver_timestamp', 'ingestion_timestamp',
@@ -723,6 +731,7 @@ def inputs(argv=None):
     parser.add_argument("-bt", "--beginDT", dest="start", type=str)
     parser.add_argument("-et", "--endDT", dest="stop", type=str)
     parser.add_argument("-ba", "--burst_average", dest="burst", default=False, action='store_true')
+    parser.add_argument("-t", "--type", dest="sensor_type", type=str, required=False)
     parser.add_argument("-o", "--outfile", dest="outfile", type=str, required=True)
 
     # parse the input arguments and create a parser object

--- a/python/ooi_data_explorations/uncabled/process_ctdbp.py
+++ b/python/ooi_data_explorations/uncabled/process_ctdbp.py
@@ -209,7 +209,7 @@ def main(argv=None):
 
     # Valid request, start downloading the data
     if deploy:
-        ctdbp = m2m_collect(r, '.*deployment%04d.*CTDBP.*\\.nc$')
+        ctdbp = m2m_collect(r, ('.*deployment%04d.*CTDBP.*\\.nc$' % deploy))
     else:
         ctdbp = m2m_collect(r, '.*CTDBP.*\\.nc$')
 

--- a/python/ooi_data_explorations/uncabled/process_dosta.py
+++ b/python/ooi_data_explorations/uncabled/process_dosta.py
@@ -8,25 +8,25 @@ from ooi_data_explorations.common import inputs, m2m_collect, m2m_request, get_d
 
 ATTRS = {
     'raw_oxygen_concentration': {
-        'long_name': 'Raw Dissolved Oxygen',
+        'long_name': 'Raw Dissolved Oxygen Concentration',
         'units': 'counts',
-        'comment': ('Raw dissolved oxygen concentration measurement reported in counts. Converted to the estimated '
-                    'dissolved oxygen concentration by dividing by 10000 and subtracting 10.'),
+        'comment': ('The dissolved oxygen concentration measurement reported in counts. Converted to a dissolved '
+                    'oxygen concentration measurement reported in umols/L by dividing by 10000 and subtracting 10.'),
         'data_product_identifier': 'DOCONCS-CNT_L0',
     },
-    'estimated_oxygen_concentration': {
-        'long_name': 'Estimated Dissolved Oxygen Concentration',
+    'oxygen_concentration': {
+        'long_name': 'Dissolved Oxygen Concentration',
         'standard_name': 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
         'units': 'umol L-1',
         'comment': ('Mole concentration of dissolved oxygen per unit volume, also known as Molarity, as measured by '
-                    'an optode oxygen sensor. Computed onboard the sensor using internal calibration coefficients.'),
+                    'an optode oxygen sensor. Computed on-board the sensor using internal calibration coefficients.'),
         'data_product_identifier': 'DOCONCS_L1',
     },
-    'estimated_oxygen_saturation': {
-        'long_name': 'Estimated Dissolved Oxygen Saturation',
+    'oxygen_saturation': {
+        'long_name': 'Dissolved Oxygen Saturation',
         'units': 'percent',
         'comment': ('Oxygen saturation is the percentage of dissolved oxygen relative to the absolute solubility of '
-                    'oxygen at a particular water temperature. Computed onboard the sensor using internal calibration '
+                    'oxygen at a particular water temperature. Computed on-board the sensor using internal calibration '
                     'coefficients.'),
     },
     'optode_temperature': {
@@ -91,7 +91,7 @@ ATTRS = {
         'data_product_identifier': 'PRACSAL_L2'
     },
     # --> derived values
-    'oxygen_concentration': {
+    'svu_oxygen_concentration': {
         'long_name': 'Dissolved Oxygen Concentration',
         'standard_name': 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
         'units': 'umol L-1',
@@ -138,9 +138,11 @@ def dosta_datalogger(ds, burst=False):
 
     # rename some of the variables for better clarity
     rename = {
-        'dosta_abcdjm_cspp_tc_oxygen': 'oxygen_concentration',
-        'dosta_abcdjm_cspp_tc_oxygen_qc_executed': 'oxygen_concentration_qc_executed',
-        'dosta_abcdjm_cspp_tc_oxygen_qc_results': 'oxygen_concentration_qc_results',
+        'estimated_oxygen_concentration': 'oxygen_concentration',
+        'estimated_oxygen_saturation': 'oxygen_saturation',
+        'dosta_abcdjm_cspp_tc_oxygen': 'svu_oxygen_concentration',
+        'dosta_abcdjm_cspp_tc_oxygen_qc_executed': 'svu_oxygen_concentration_qc_executed',
+        'dosta_abcdjm_cspp_tc_oxygen_qc_results': 'svu_oxygen_concentration_qc_results',
         'dissolved_oxygen': 'oxygen_concentration_corrected',
         'dissolved_oxygen_qc_executed': 'oxygen_concentration_corrected_qc_executed',
         'dissolved_oxygen_qc_results': 'oxygen_concentration_corrected_qc_results',
@@ -206,9 +208,9 @@ def dosta_ctdbp_datalogger(ds):
 
     # rename some of the variables for better clarity
     rename = {
-        'dosta_ln_optode_oxygen': 'estimated_oxygen_concentration',
-        'dosta_ln_optode_oxygen_qc_executed': 'estimated_oxygen_concentration_qc_executed',
-        'dosta_ln_optode_oxygen_qc_results': 'estimated_oxygen_concentration_qc_results',
+        'dosta_ln_optode_oxygen': 'oxygen_concentration',
+        'dosta_ln_optode_oxygen_qc_executed': 'oxygen_concentration_qc_executed',
+        'dosta_ln_optode_oxygen_qc_results': 'oxygen_concentration_qc_results',
         'dissolved_oxygen': 'oxygen_concentration_corrected',
         'dissolved_oxygen_qc_executed': 'oxygen_concentration_corrected_qc_executed',
         'dissolved_oxygen_qc_results': 'oxygen_concentration_corrected_qc_results',
@@ -248,9 +250,9 @@ def dosta_ctdbp_instrument(ds):
     # rename some of the variables for better clarity
     rename = {
         'oxygen': 'raw_oxygen_concentration',
-        'ctd_tc_oxygen': 'estimated_oxygen_concentration',
-        'ctd_tc_oxygen_qc_executed': 'estimated_oxygen_concentration_qc_executed',
-        'ctd_tc_oxygen_qc_results': 'estimated_oxygen_concentration_qc_results',
+        'ctd_tc_oxygen': 'oxygen_concentration',
+        'ctd_tc_oxygen_qc_executed': 'oxygen_concentration_qc_executed',
+        'ctd_tc_oxygen_qc_results': 'oxygen_concentration_qc_results',
         'dissolved_oxygen': 'oxygen_concentration_corrected',
         'dissolved_oxygen_qc_executed': 'oxygen_concentration_corrected_qc_executed',
         'dissolved_oxygen_qc_results': 'oxygen_concentration_corrected_qc_results',

--- a/python/ooi_data_explorations/uncabled/process_dosta.py
+++ b/python/ooi_data_explorations/uncabled/process_dosta.py
@@ -41,7 +41,7 @@ ATTRS = {
         'long_name': 'Calibrated Phase Difference',
         'units': 'degrees',
         'comment': ('The optode measures oxygen by exciting a special platinum porphyrin complex embedded in a '
-                    'gas permeable foil with modulated blue light. The Optode measures the phase shift of the '
+                    'gas permeable foil with modulated blue light. The optode measures the phase shift of the '
                     'returned red light. By linearizing and temperature compensating, with an incorporated '
                     'temperature sensor, the absolute O2 concentration can be determined.'),
         'data_product_identifier': 'DOCONCS-VLT_L0',
@@ -96,8 +96,9 @@ ATTRS = {
         'standard_name': 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
         'units': 'umol L-1',
         'comment': ('Mole concentration of dissolved oxygen per unit volume, also known as Molarity, as measured by '
-                    'an optode oxygen sensor. Compares to the estimated_oxygen_concentration, but recomputed using '
-                    'the calibrated phase and optode thermistor temperature via the Stern-Volmer-Uchida equation.'),
+                    'an optode oxygen sensor. Compares to the oxygen_concentration computed on-board the sensor, '
+                    'but is recomputed using factory calibration coefficients, the calibrated phase values and '
+                    'the optode thermistor temperature via the Stern-Volmer-Uchida equation.'),
         'data_product_identifier': 'DOCONCS_L1'
     },
     'oxygen_concentration_corrected': {

--- a/python/ooi_data_explorations/uncabled/process_dosta.py
+++ b/python/ooi_data_explorations/uncabled/process_dosta.py
@@ -305,7 +305,7 @@ def main(argv=None):
 
     # Valid request, start downloading the data
     if deploy:
-        dosta = m2m_collect(r, '.*deployment%04d.*DOSTA.*\\.nc$')
+        dosta = m2m_collect(r, ('.*deployment%04d.*DOSTA.*\\.nc$' % deploy))
     else:
         dosta = m2m_collect(r, '.*DOSTA.*\\.nc$')
 

--- a/python/ooi_data_explorations/uncabled/process_dosta.py
+++ b/python/ooi_data_explorations/uncabled/process_dosta.py
@@ -313,7 +313,7 @@ def main(argv=None):
         exit_text = ('Data unavailable for %s-%s-%s. Check request.' % (site, node, sensor))
         raise SystemExit(exit_text)
 
-    if sensor_type in ['solo', 'ctdbp']:
+    if not sensor_type in ['solo', 'ctdbp']:
         exit_text = 'You need to specify the type of DOSTA in order to process: solo or ctdbp'
         raise SystemExit(exit_text)
 
@@ -322,9 +322,10 @@ def main(argv=None):
         dosta = dosta_datalogger(dosta, burst)
 
     if sensor_type == 'ctdbp':
-        if method in ['telemetered', 'recoverd_host']:
+        if method in ['telemetered', 'recovered_host']:
             dosta = dosta_ctdbp_datalogger(dosta)
-
+        else:
+            dosta = dosta_ctdbp_instrument(dosta)
 
     vocab = get_vocabulary(site, node, sensor)[0]
     dosta = update_dataset(dosta, vocab['maxdepth'])

--- a/python/ooi_data_explorations/uncabled/process_dosta.py
+++ b/python/ooi_data_explorations/uncabled/process_dosta.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import numpy as np
+import os
+
+from ooi_data_explorations.common import inputs, m2m_collect, m2m_request, get_deployment_dates, \
+    get_vocabulary, update_dataset, dt64_epoch, ENCODINGS
+
+ATTRS = {
+    'raw_oxygen_concentration': {
+        'long_name': 'Raw Dissolved Oxygen',
+        'units': 'counts',
+        'comment': ('Raw dissolved oxygen concentration measurement reported in counts. Converted to the estimated '
+                    'dissolved oxygen concentration by dividing by 10000 and subtracting 10.'),
+        'data_product_identifier': 'DOCONCS-CNT_L0',
+    },
+    'estimated_oxygen_concentration': {
+        'long_name': 'Estimated Dissolved Oxygen Concentration',
+        'standard_name': 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+        'units': 'umol L-1',
+        'comment': ('Mole concentration of dissolved oxygen per unit volume, also known as Molarity, as measured by '
+                    'an optode oxygen sensor. Computed onboard the sensor using internal calibration coefficients.'),
+        'data_product_identifier': 'DOCONCS_L1',
+    },
+    'estimated_oxygen_saturation': {
+        'long_name': 'Estimated Dissolved Oxygen Saturation',
+        'units': 'percent',
+        'comment': ('Oxygen saturation is the percentage of dissolved oxygen relative to the absolute solubility of '
+                    'oxygen at a particular water temperature. Computed onboard the sensor using internal calibration '
+                    'coefficients.'),
+    },
+    'optode_temperature': {
+        'long_name': 'Optode Thermistor Temperature',
+        'standard_name': 'temperature_of_sensor_for_oxygen_in_sea_water',
+        'units': 'degrees_Celsius',
+        'comment': ('Optode internal thermistor temperature used in calculation of the absolute oxygen ' 
+                    'concentration. This is not the in-situ sea water temperature, though it will be very close.'),
+        'ancillary_variables': 'raw_temperature',
+    },
+    'calibrated_phase': {
+        'long_name': 'Calibrated Phase Difference',
+        'units': 'degrees',
+        'comment': ('The optode measures oxygen by exciting a special platinum porphyrin complex embedded in a '
+                    'gas permeable foil with modulated blue light. The Optode measures the phase shift of the '
+                    'returned red light. By linearizing and temperature compensating, with an incorporated '
+                    'temperature sensor, the absolute O2 concentration can be determined.'),
+        'data_product_identifier': 'DOCONCS-VLT_L0',
+    },
+    'temp_compensated_phase': {
+        'long_name': 'Temperature Compensated Calibrated Phase',
+        'comment': 'Temperature compensated (using the temperature data from an onboard thermistor) calibrated phase '
+                   'difference.',
+        'units': 'degrees',
+        'ancillary_variables': 'optode_temperature, calibrated_phase'
+    },
+    'raw_temperature': {
+        'long_name': 'Raw Optode Thermistor Temperature',
+        'units': 'mV',
+        'comment': ('The optode includes an integrated internal thermistor to measure the temperature at '
+                    'the sensing foil.'),
+    },
+    # co-located CTD data
+    'seawater_temperature': {
+        'long_name': 'Sea Water Temperature',
+        'standard_name': 'sea_water_temperature',
+        'units': 'degrees_Celsius',
+        'comment': ('Sea water temperature is the in situ temperature of the sea water. Measurements are from a '
+                    'co-located CTD'),
+        'data_product_identifier': 'TEMPWAT_L1'
+    },
+    'seawater_pressure': {
+        'long_name': 'Sea Water Pressure',
+        'standard_name': 'sea_water_pressure_due_to_sea_water',
+        'units': 'dbar',
+        'comment': ('Sea Water Pressure refers to the pressure exerted on a sensor in situ by the weight of the ' 
+                    'column of seawater above it. It is calculated by subtracting one standard atmosphere from the ' 
+                    'absolute pressure at the sensor to remove the weight of the atmosphere on top of the water ' 
+                    'column. The pressure at a sensor in situ provides a metric of the depth of that sensor. '
+                    'Measurements are from a co-located CTD.'),
+        'data_product_identifier': 'PRESWAT_L1'
+    },
+    'practical_salinity': {
+        'long_name': 'Sea Water Practical Salinity',
+        'standard_name': 'sea_water_practical_salinity',
+        'units': '1',
+        'comment': ('Salinity is generally defined as the concentration of dissolved salt in a parcel of sea water. ' 
+                    'Practical Salinity is a more specific unitless quantity calculated from the conductivity of ' 
+                    'sea water and adjusted for temperature and pressure. It is approximately equivalent to Absolute ' 
+                    'Salinity (the mass fraction of dissolved salt in sea water), but they are not interchangeable. '
+                    'Measurements are from a co-located CTD.'),
+        'data_product_identifier': 'PRACSAL_L2'
+    },
+    # --> derived values
+    'oxygen_concentration': {
+        'long_name': 'Dissolved Oxygen Concentration',
+        'standard_name': 'mole_concentration_of_dissolved_molecular_oxygen_in_sea_water',
+        'units': 'umol L-1',
+        'comment': ('Mole concentration of dissolved oxygen per unit volume, also known as Molarity, as measured by '
+                    'an optode oxygen sensor. Compares to the estimated_oxygen_concentration, but recomputed using '
+                    'the calibrated phase and optode thermistor temperature via the Stern-Volmer-Uchida equation.'),
+        'data_product_identifier': 'DOCONCS_L1'
+    },
+    'oxygen_concentration_corrected': {
+        'long_name': 'Corrected Dissolved Oxygen Concentration',
+        'standard_name': 'moles_of_oxygen_per_unit_mass_in_sea_water',
+        'units': 'umol kg-1',
+        'comments': ('The dissolved oxygen concentration from the Stable Response Dissolved Oxygen Instrument is a '
+                     'measure of the concentration of gaseous oxygen mixed in seawater. This data product corrects '
+                     'the dissolved oxygen concentration for the effects of salinity, temperature, and pressure with '
+                     'data from a co-located CTD.'),
+        'data_product_identifier': 'DOXYGEN_L2'
+    }
+}
+
+
+def dosta_datalogger(ds, burst=False):
+    """
+    Takes dosta data recorded by the data loggers used in the CGSN/EA moorings
+    and cleans up the data set to make it more user-friendly. Primary task is
+    renaming the alphabet soup parameter names and dropping some parameters
+    that are of no use/value.
+
+    :param ds: initial dosta data set downloaded from OOI via the M2M system
+    :param burst: resample the data to the defined time interval
+    :return ds: cleaned up data set
+    """
+    # drop some of the variables:
+    #   dcl_controller_timestamp == time, redundant so can remove
+    #   internal_timestamp, there is no internal instrument clock
+    #   product_number, these are all 4831s and captured in global attributes
+    #   estimated_oxygen_concentration_qc_executed, preliminary data product no QC tests should be applied
+    #   estimated_oxygen_concentration_qc_results, preliminary data product no QC tests should be applied
+    #   estimated_oxygen_saturation_qc_executed, preliminary data product no QC tests should be applied
+    #   estimated_oxygen_saturation_qc_results, preliminary data product no QC tests should be applied
+    ds = ds.drop(['dcl_controller_timestamp', 'product_number', 'internal_timestamp',
+                  'estimated_oxygen_concentration_qc_executed', 'estimated_oxygen_concentration_qc_results',
+                  'estimated_oxygen_saturation_qc_executed', 'estimated_oxygen_saturation_qc_results'])
+
+    # rename some of the variables for better clarity
+    rename = {
+        'dosta_abcdjm_cspp_tc_oxygen': 'oxygen_concentration',
+        'dosta_abcdjm_cspp_tc_oxygen_qc_executed': 'oxygen_concentration_qc_executed',
+        'dosta_abcdjm_cspp_tc_oxygen_qc_results': 'oxygen_concentration_qc_results',
+        'dissolved_oxygen': 'oxygen_concentration_corrected',
+        'dissolved_oxygen_qc_executed': 'oxygen_concentration_corrected_qc_executed',
+        'dissolved_oxygen_qc_results': 'oxygen_concentration_corrected_qc_results',
+        'int_ctd_pressure': 'seawater_pressure',
+        'temp': 'seawater_temperature',
+    }
+    ds = ds.rename(rename)
+
+    # reset variable attributes using dictionary above
+    for v in ds.variables:
+        if v in ATTRS.keys():
+            ds[v].attrs = ATTRS[v]
+
+    # add original OOINet variable name as an attribute if renamed
+    for key, value in rename.items():
+        ds[value].attrs['ooinet_variable_name'] = key
+
+    if burst:   # re-sample the data to a defined time interval using a median average
+        # create the burst averaging
+        burst = ds
+        burst['time'] = burst['time'] - np.timedelta64(450, 's')    # center time windows for 15 minute bursts
+        burst = burst.resample(time='15Min', keep_attrs=True, skipna=True).median()
+        burst = burst.where(~np.isnan(burst.deployment), drop=True)
+
+        # reset the attributes...which keep_attrs should do...
+        burst.attrs = ds.attrs
+        for v in burst.variables:
+            burst[v].attrs = ds[v].attrs
+
+        # save the newly average data
+        ds = burst
+
+    return ds
+
+
+def dosta_ctdbp_datalogger(ds):
+    """
+    Takes data from DOSTAs connected to the CTDBP, with the data recorded by
+    the datalogger (used by some of the EA moorings) and cleans up the data 
+    set to make it more user-friendly. Primary task is renaming the alphabet 
+    soup parameter names and dropping some parameters that are of limited or 
+    no use/value.
+
+    :param ds: initial dosta data set downloaded from OOI via the M2M system
+    :return ds: cleaned up data set
+    """
+    # drop some of the variables:
+    #   dcl_controller_timestamp == time, redundant so can remove
+    #   date_time_string == internal_timestamp, redundant so can remove
+    ds = ds.drop(['dcl_controller_timestamp', 'date_time_string'])
+
+    # convert the time values from a datetime64[ns] object to a floating point number with the time in seconds
+    ds['internal_timestamp'] = ('time', dt64_epoch(ds.internal_timestamp))
+    ds['internal_timestamp'].attrs = dict({
+        'long_name': 'Internal CTD Clock Time',
+        'standard_name': 'time',
+        'units': 'seconds since 1970-01-01 00:00:00 0:00',
+        'calendar': 'gregorian',
+        'comment': ('Comparing the instrument internal clock versus the GPS referenced sampling time will allow for '
+                    'calculations of the instrument clock offset and drift. Useful when working with the '
+                    'recovered instrument data where no external GPS referenced clock is available.')
+    })
+
+    # rename some of the variables for better clarity
+    rename = {
+        'dosta_ln_optode_oxygen': 'estimated_oxygen_concentration',
+        'dosta_ln_optode_oxygen_qc_executed': 'estimated_oxygen_concentration_qc_executed',
+        'dosta_ln_optode_oxygen_qc_results': 'estimated_oxygen_concentration_qc_results',
+        'dissolved_oxygen': 'oxygen_concentration_corrected',
+        'dissolved_oxygen_qc_executed': 'oxygen_concentration_corrected_qc_executed',
+        'dissolved_oxygen_qc_results': 'oxygen_concentration_corrected_qc_results',
+        'int_ctd_pressure': 'seawater_pressure',
+        'temp': 'seawater_temperature',
+    }
+    ds = ds.rename(rename)
+
+    # reset variable attributes using dictionary above
+    for v in ds.variables:
+        if v in ATTRS.keys():
+            ds[v].attrs = ATTRS[v]
+
+    # add original OOINet variable name as an attribute if renamed
+    for key, value in rename.items():
+        ds[value].attrs['ooinet_variable_name'] = key
+
+    return ds
+
+
+def dosta_ctdbp_instrument(ds):
+    """
+    Takes data from DOSTAs connected to the CTDBP, with the data recorded by
+    the CTDBP (used by some of the EA moorings) and cleans up the data
+    set to make it more user-friendly. Primary task is renaming the alphabet
+    soup parameter names and dropping some parameters that are of limited or
+    no use/value.
+
+    :param ds: initial dosta data set downloaded from OOI via the M2M system
+    :return ds: cleaned up data set
+    """
+    # drop some of the variables:
+    #   ctd_time == time, redundant so can remove
+    #   internal_timestamp == time, redundant so can remove
+    ds = ds.drop(['internal_timestamp', 'ctd_time'])
+
+    # rename some of the variables for better clarity
+    rename = {
+        'oxygen': 'raw_oxygen_concentration',
+        'ctd_tc_oxygen': 'estimated_oxygen_concentration',
+        'ctd_tc_oxygen_qc_executed': 'estimated_oxygen_concentration_qc_executed',
+        'ctd_tc_oxygen_qc_results': 'estimated_oxygen_concentration_qc_results',
+        'dissolved_oxygen': 'oxygen_concentration_corrected',
+        'dissolved_oxygen_qc_executed': 'oxygen_concentration_corrected_qc_executed',
+        'dissolved_oxygen_qc_results': 'oxygen_concentration_corrected_qc_results',
+        'int_ctd_pressure': 'seawater_pressure',
+        'temp': 'seawater_temperature',
+    }
+    ds = ds.rename(rename)
+
+    # reset variable attributes using dictionary above
+    for v in ds.variables:
+        if v in ATTRS.keys():
+            ds[v].attrs = ATTRS[v]
+
+    # add original OOINet variable name as an attribute if renamed
+    for key, value in rename.items():
+        ds[value].attrs['ooinet_variable_name'] = key
+
+    return ds
+
+
+def main(argv=None):
+    args = inputs(argv)
+    site = args.site
+    node = args.node
+    sensor = args.sensor
+    method = args.method
+    stream = args.stream
+    deploy = args.deploy
+    start = args.start
+    stop = args.stop
+    burst = args.burst
+    sensor_type = args.sensor_type
+
+    # determine the start and stop times for the data request based on either the deployment number or user entered
+    # beginning and ending dates.
+    if not deploy or (start and stop):
+        return SyntaxError('You must specify either a deployment number or beginning and end dates of interest.')
+    else:
+        if deploy:
+            # Determine start and end dates based on the deployment number
+            start, stop = get_deployment_dates(site, node, sensor, deploy)
+            if not start or not stop:
+                exit_text = ('Deployment dates are unavailable for %s-%s-%s, deployment %02d.' % (site, node, sensor,
+                                                                                                  deploy))
+                raise SystemExit(exit_text)
+
+    # Request the data for download
+    r = m2m_request(site, node, sensor, method, stream, start, stop)
+    if not r:
+        exit_text = ('Request failed for %s-%s-%s. Check request.' % (site, node, sensor))
+        raise SystemExit(exit_text)
+
+    # Valid request, start downloading the data
+    if deploy:
+        dosta = m2m_collect(r, '.*deployment%04d.*DOSTA.*\\.nc$')
+    else:
+        dosta = m2m_collect(r, '.*DOSTA.*\\.nc$')
+
+    if not dosta:
+        exit_text = ('Data unavailable for %s-%s-%s. Check request.' % (site, node, sensor))
+        raise SystemExit(exit_text)
+
+    if sensor_type in ['solo', 'ctdbp']:
+        exit_text = 'You need to specify the type of DOSTA in order to process: solo or ctdbp'
+        raise SystemExit(exit_text)
+
+    # clean-up and reorganize based on the type and data delivery method
+    if sensor_type == 'solo':
+        dosta = dosta_datalogger(dosta, burst)
+
+    if sensor_type == 'ctdbp':
+        if method in ['telemetered', 'recoverd_host']:
+            dosta = dosta_ctdbp_datalogger(dosta)
+
+
+    vocab = get_vocabulary(site, node, sensor)[0]
+    dosta = update_dataset(dosta, vocab['maxdepth'])
+
+    # save the data to disk
+    out_file = os.path.abspath(args.outfile)
+    if not os.path.exists(os.path.dirname(out_file)):
+        os.makedirs(os.path.dirname(out_file))
+
+    dosta.to_netcdf(out_file, mode='w', format='NETCDF4', engine='h5netcdf', encoding=ENCODINGS)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/ooi_data_explorations/uncabled/process_flort.py
+++ b/python/ooi_data_explorations/uncabled/process_flort.py
@@ -123,8 +123,7 @@ def flort_datalogger(ds, burst=True):
 
     # lots of renaming here to get a better defined data set with cleaner attributes
     rename = {
-        'temp': 'temperature',
-        'practical_salinity': 'salinity',
+        'temp': 'seawater_temperature',
         'raw_signal_chl': 'raw_chlorophyll',
         'fluorometric_chlorophyll_a': 'estimated_chlorophyll',
         'fluorometric_chlorophyll_a_qc_executed': 'estimated_chlorophyll_qc_executed',

--- a/python/ooi_data_explorations/uncabled/process_flort.py
+++ b/python/ooi_data_explorations/uncabled/process_flort.py
@@ -249,7 +249,7 @@ def main(argv=None):
 
     # Valid request, start downloading the data
     if deploy:
-        flort = m2m_collect(r, '.*deployment%04d.*FLORT.*\\.nc$')
+        flort = m2m_collect(r, ('.*deployment%04d.*FLORT.*\\.nc$' % deploy))
     else:
         flort = m2m_collect(r, '.*FLORT.*\\.nc$')
 

--- a/python/ooi_data_explorations/uncabled/process_phsen.py
+++ b/python/ooi_data_explorations/uncabled/process_phsen.py
@@ -9,7 +9,7 @@ from ooi_data_explorations.common import inputs, m2m_collect, m2m_request, get_d
     get_vocabulary, dt64_epoch, update_dataset, ENCODINGS
 
 # Setup some attributes, used to replace those incorrectly set, or needed after the processing below
-PHSEN = {
+ATTRS = {
     'unique_id': {
         'long_name': 'Instrument Unique ID',
         'comment': ('One byte checksum summary of the instrument serial number, name, calibration date and firmware ' +
@@ -224,8 +224,8 @@ def phsen_datalogger(ds):
 
     # reset some of the variable attributes, and ...
     for v in ds.variables:  # variable level attributes
-        if v in PHSEN:
-            ds[v].attrs = PHSEN[v]
+        if v in ATTRS.keys():
+            ds[v].attrs = ATTRS[v]
 
     # ... add the renamed information
     for key, value in rename.items():
@@ -309,8 +309,8 @@ def phsen_instrument(ds):
 
     # reset some of the variable attributes, and ...
     for v in ds.variables:  # variable level attributes
-        if v in PHSEN:
-            ds[v].attrs = PHSEN[v]
+        if v in ATTRS.keys():
+            ds[v].attrs = ATTRS[v]
 
     # ... add the renamed information
     for key, value in rename.items():
@@ -402,8 +402,8 @@ def phsen_imodem(ds):
 
     # reset some of the variable attributes, and ...
     for v in ds.variables:  # variable level attributes
-        if v in PHSEN:
-            ds[v].attrs = PHSEN[v]
+        if v in ATTRS.keys():
+            ds[v].attrs = ATTRS[v]
 
     # ... add the renamed information
     for key, value in rename.items():

--- a/python/utilities/harvesters/harvest_ce_dosta.sh
+++ b/python/utilities/harvesters/harvest_ce_dosta.sh
@@ -18,20 +18,20 @@ PYTHON="python -m ooi_data_explorations.uncabled.process_dosta"
 ### CE01ISSM ###
 BASE_FLAGS="-s CE01ISSM -n RID16 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce01issm/nsif/dosta/ce01issm.nsif.dosta"
-for i in $(seq -f "%02g" 1 12); do
-	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+for i in $(seq -f "%02g" 11 12); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 13 -o "$BASE_FILE.deploy13.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE01ISSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce01issm/seafloor/dosta/ce01issm.seafloor.dosta"
-for i in $(seq -f "%02g" 1 12); do
-	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+for i in $(seq -f "%02g" 11 12); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 13 -o "$BASE_FILE.deploy13.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
@@ -39,9 +39,9 @@ $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctd
 ### CE02SHSM ###
 BASE_FLAGS="-s CE02SHSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce02shsm/nsif/dosta/ce02shsm.nsif.dosta"
-for i in $(seq -f "%02g" 1 10); do
-		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
-		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+for i in $(seq -f "%02g" 9 10); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
@@ -49,9 +49,9 @@ $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 
 ### CE04OSSM ###
 BASE_FLAGS="-s CE04OSSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce04ossm/nsif/dosta/ce04ossm.nsif.dosta"
-for i in $(seq -f "%02g" 1 9); do
-		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
-		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+for i in $(seq -f "%02g" 8 9); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 10 -ba -o "$BASE_FILE.deploy10.telemetered.dosta_abcdjm_dcl_instrument.nc"
@@ -59,20 +59,20 @@ $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 
 ### CE06ISSM ###
 BASE_FLAGS="-s CE06ISSM -n RID16 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce06issm/nsif/dosta/ce06issm.nsif.dosta"
-for i in $(seq -f "%02g" 1 11); do
-	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+for i in $(seq -f "%02g" 10 11); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 12 -o "$BASE_FILE.deploy12.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE06ISSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce06issm/seafloor/dosta/ce06issm.seafloor.dosta"
-for i in $(seq -f "%02g" 1 11); do
-	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+for i in $(seq -f "%02g" 10 11); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 12 -o "$BASE_FILE.deploy12.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
@@ -80,16 +80,16 @@ $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctd
 ### CE07SHSM ###
 BASE_FLAGS="-s CE07SHSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce07shsm/nsif/dosta/ce07shsm.nsif.dosta"
-for i in $(seq -f "%02g" 1 10); do
-		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
-		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+for i in $(seq -f "%02g" 9 10); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE07SHSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce07shsm/seafloor/dosta/ce07shsm.seafloor.dosta"
-for i in $(seq -f "%02g" 1 10); do
+for i in $(seq -f "%02g" 9 10); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
     $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
@@ -97,20 +97,19 @@ done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 11 -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
-
 ### CE09OSSM ###
 BASE_FLAGS="-s CE09OSSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce09ossm/nsif/dosta/ce09ossm.nsif.dosta"
-for i in $(seq -f "%02g" 1 10); do
-		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
-		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+for i in $(seq -f "%02g" 9 10); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
 # Current deployment
 $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE09OSSM -n MFD37 -sn 03-CTDBPE000"
 BASE_FILE="${HOME}/ooidata/m2m/ce09ossm/seafloor/dosta/ce09ossm.seafloor.dosta"
-for i in $(seq -f "%02g" 1 10); do
+for i in $(seq -f "%02g" 9 10); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
     $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"

--- a/python/utilities/harvesters/harvest_ce_dosta.sh
+++ b/python/utilities/harvesters/harvest_ce_dosta.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# harvest_ce_dosta.sh
+#
+# Harvest the dosta data from all of the OOI Coastal Endurance moorings. Data
+# sets include telemetered and recovered host and instrument data. Data is
+# downloaded from OOI Net and reworked to create a cleaner and more consistent
+# set of files named and organized by the mooring, mooring sub-location, data
+# delivery method and deployment.
+#
+# C. Wingard, 2020-08-21 -- Initial code
+
+# set the base directory python command for all subsequent processing
+. $(dirname $CONDA_EXE)/../etc/profile.d/conda.sh
+conda activate ooi
+PYTHON="python -m ooi_data_explorations.uncabled.process_dosta"
+
+### CE01ISSM ###
+BASE_FLAGS="-s CE01ISSM -n RID16 -sn 03-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce01issm/nsif/dosta/ce01issm.nsif.dosta"
+for i in $(seq -f "%02g" 1 12); do
+	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 13 -o "$BASE_FILE.deploy13.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+
+BASE_FLAGS="-s CE01ISSM -n MFD37 -sn 03-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce01issm/seafloor/dosta/ce01issm.seafloor.dosta"
+for i in $(seq -f "%02g" 1 12); do
+	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 13 -o "$BASE_FILE.deploy13.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+
+### CE02SHSM ###
+BASE_FLAGS="-s CE02SHSM -n RID27 -sn 04-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce02shsm/nsif/dosta/ce02shsm.nsif.dosta"
+for i in $(seq -f "%02g" 1 10); do
+		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
+
+### CE04OSSM ###
+BASE_FLAGS="-s CE04OSSM -n RID27 -sn 04-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce04ossm/nsif/dosta/ce04ossm.nsif.dosta"
+for i in $(seq -f "%02g" 1 9); do
+		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 10 -ba -o "$BASE_FILE.deploy10.telemetered.dosta_abcdjm_dcl_instrument.nc"
+
+### CE06ISSM ###
+BASE_FLAGS="-s CE06ISSM -n RID16 -sn 03-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce06issm/nsif/dosta/ce06issm.nsif.dosta"
+for i in $(seq -f "%02g" 1 11); do
+	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 12 -o "$BASE_FILE.deploy12.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+
+BASE_FLAGS="-s CE06ISSM -n MFD37 -sn 03-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce06issm/seafloor/dosta/ce06issm.seafloor.dosta"
+for i in $(seq -f "%02g" 1 11); do
+	$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+	$PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 12 -o "$BASE_FILE.deploy12.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+
+### CE07SHSM ###
+BASE_FLAGS="-s CE07SHSM -n RID27 -sn 04-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce07shsm/nsif/dosta/ce07shsm.nsif.dosta"
+for i in $(seq -f "%02g" 1 10); do
+		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
+
+BASE_FLAGS="-s CE07SHSM -n MFD37 -sn 03-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce07shsm/seafloor/dosta/ce07shsm.seafloor.dosta"
+for i in $(seq -f "%02g" 1 10); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 11 -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+
+
+### CE09OSSM ###
+BASE_FLAGS="-s CE09OSSM -n RID27 -sn 04-DOSTAD000"
+BASE_FILE="${HOME}/ooidata/m2m/ce09ossm/nsif/dosta/ce09ossm.nsif.dosta"
+for i in $(seq -f "%02g" 1 10); do
+		$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
+		$PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
+
+BASE_FLAGS="-s CE09OSSM -n MFD37 -sn 03-CTDBPE000"
+BASE_FILE="${HOME}/ooidata/m2m/ce09ossm/seafloor/dosta/ce09ossm.seafloor.dosta"
+for i in $(seq -f "%02g" 1 10); do
+    $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+done
+# Current deployment
+$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 11 -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"

--- a/python/utilities/harvesters/harvest_ce_dosta.sh
+++ b/python/utilities/harvesters/harvest_ce_dosta.sh
@@ -18,101 +18,81 @@ PYTHON="python -m ooi_data_explorations.uncabled.process_dosta"
 ### CE01ISSM ###
 BASE_FLAGS="-s CE01ISSM -n RID16 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce01issm/nsif/dosta/ce01issm.nsif.dosta"
-for i in $(seq -f "%02g" 11 12); do
+for i in $(seq -f "%02g" 1 13); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 13 -o "$BASE_FILE.deploy13.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE01ISSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce01issm/seafloor/dosta/ce01issm.seafloor.dosta"
-for i in $(seq -f "%02g" 11 12); do
+for i in $(seq -f "%02g" 1 13); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 13 -o "$BASE_FILE.deploy13.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 ### CE02SHSM ###
 BASE_FLAGS="-s CE02SHSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce02shsm/nsif/dosta/ce02shsm.nsif.dosta"
-for i in $(seq -f "%02g" 9 10); do
+for i in $(seq -f "%02g" 1 11); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
 
 ### CE04OSSM ###
 BASE_FLAGS="-s CE04OSSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce04ossm/nsif/dosta/ce04ossm.nsif.dosta"
-for i in $(seq -f "%02g" 8 9); do
+for i in $(seq -f "%02g" 1 10); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 10 -ba -o "$BASE_FILE.deploy10.telemetered.dosta_abcdjm_dcl_instrument.nc"
 
 ### CE06ISSM ###
 BASE_FLAGS="-s CE06ISSM -n RID16 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce06issm/nsif/dosta/ce06issm.nsif.dosta"
-for i in $(seq -f "%02g" 10 11); do
+for i in $(seq -f "%02g" 1 12); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 12 -o "$BASE_FILE.deploy12.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE06ISSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce06issm/seafloor/dosta/ce06issm.seafloor.dosta"
-for i in $(seq -f "%02g" 10 11); do
+for i in $(seq -f "%02g" 1 12); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 12 -o "$BASE_FILE.deploy12.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 ### CE07SHSM ###
 BASE_FLAGS="-s CE07SHSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce07shsm/nsif/dosta/ce07shsm.nsif.dosta"
-for i in $(seq -f "%02g" 9 10); do
+for i in $(seq -f "%02g" 1 11); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
 
 BASE_FLAGS="-s CE07SHSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce07shsm/seafloor/dosta/ce07shsm.seafloor.dosta"
-for i in $(seq -f "%02g" 9 10); do
+for i in $(seq -f "%02g" 1 11); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 11 -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
 
 ### CE09OSSM ###
 BASE_FLAGS="-s CE09OSSM -n RID27 -sn 04-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce09ossm/nsif/dosta/ce09ossm.nsif.dosta"
-for i in $(seq -f "%02g" 9 10); do
+for i in $(seq -f "%02g" 1 11); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_dcl_instrument_recovered -t solo -dp $i -ba -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_dcl_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_dcl_instrument -t solo -dp 11 -ba -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_dcl_instrument.nc"
 
-BASE_FLAGS="-s CE09OSSM -n MFD37 -sn 03-CTDBPE000"
+BASE_FLAGS="-s CE09OSSM -n MFD37 -sn 03-DOSTAD000"
 BASE_FILE="${HOME}/ooidata/m2m/ce09ossm/seafloor/dosta/ce09ossm.seafloor.dosta"
-for i in $(seq -f "%02g" 9 10); do
+for i in $(seq -f "%02g" 1 11); do
     $PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"
     $PYTHON $BASE_FLAGS -mt recovered_host -st dosta_abcdjm_ctdbp_dcl_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_host.dosta_abcdjm_ctdbp_dcl_instrument_recovered.nc"
-    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument.nc"
+    $PYTHON $BASE_FLAGS -mt recovered_inst -st dosta_abcdjm_ctdbp_instrument_recovered -t ctdbp -dp $i -o "$BASE_FILE.deploy$i.recovered_inst.dosta_abcdjm_ctdbp_instrument_recovered.nc"
 done
-# Current deployment
-$PYTHON $BASE_FLAGS -mt telemetered -st dosta_abcdjm_ctdbp_dcl_instrument -t ctdbp -dp 11 -o "$BASE_FILE.deploy11.telemetered.dosta_abcdjm_ctdbp_dcl_instrument.nc"


### PR DESCRIPTION
Adds a processor for the uncabled coastal surface mooring DOSTAs, with a harverster script for the Endurance Array instances. Processor resets the different variable names for the dissolved oxygen measurement used in the different dataset types (telemetered, recovered_inst and solo versus connected to a CTDBP) and corrects several errors in the attributes reported from OOINet.