### PR TITLE
Bug fix for QARTOD executed trap

### DIFF
--- a/python/ooi_data_explorations/common.py
+++ b/python/ooi_data_explorations/common.py
@@ -520,12 +520,12 @@ def process_file(catalog_file):
     if not ds:
         return None
 
-    # address error in how the *_qartod_executed variables are set
-    qartod_pattern = re.compile(r'^.+_qartod_executed.+$')
+    # addresses error in how the *_qartod_executed variables are set
+    qartod_pattern = re.compile(r'^.+_qartod_executed$')
     for v in ds.variables:
         if qartod_pattern.match(v):
-            # the shape of the QARTOD executed should compare to the provenance variable
-            if ds[v].shape[0] != ds['provenance'].shape[0]:
+            # the shape of the QARTOD executed variables should compare to the provenance variable
+            if ds[v].shape != ds['provenance'].shape:
                 ds = ds.drop_vars(v)
 
     ds = ds.swap_dims({'obs': 'time'})


### PR DESCRIPTION
The QARTOD executed variable is incorrectly shaped coming out of OOINet. This breaks merging multiple xarray datasets. Until such time as the QARTOD executed variable is correctly shaped, this code will catch and drop those variables. 