### PR TITLE
Bug correction in file attribute assignments

### DIFF
--- a/matlab/utilities/process_files.m
+++ b/matlab/utilities/process_files.m
@@ -72,9 +72,10 @@ if sum(m) == 1
             'table', 'table', 'table'};
         data = addprop(data, prop_names, prop_types);    
         for i = 1:size(prop_types, 2)
-            m = reshape(strcmp({file_info.Attributes.Name}, prop_names{i}), ...
-                size(file_info.Attributes));
-            data.Properties.CustomProperties.(prop_names{i}) = file_info.Attributes(m).Value;
+            m = reshape(strcmp({file_info.Attributes.Name}, prop_names{i}), size(file_info.Attributes));
+            if sum(m) == 1
+                data.Properties.CustomProperties.(prop_names{i}) = file_info.Attributes(m).Value;
+            end %if
         end %for
         clear prop_names prop_types i
     end %if


### PR DESCRIPTION
Adds a check for the string comparison size before attempting to add it to the timetable attributes.

Corrects a bug identified by Jon Fram. Before the correction, this request fails:

`ctd = load_gc_thredds('CE02SHSP', 'SP001', '08-CTDPFJ000', 'recovered_cspp', 'ctdpf_j_cspp_instrument_recovered', 'deployment0037.*CTDPF.*\.nc$');`

After applying the fix, it works as expected.