### PR TITLE
Adjust Matlab Regex for Newer TDS

### DIFF
--- a/matlab/utilities/process_files.m
+++ b/matlab/utilities/process_files.m
@@ -16,10 +16,11 @@ function nc_files = list_files(url, tag)
 % cwingard 2023-07-09
 
 % use webread to scrape the catalog
-catalog = webread(url);
+options = weboptions('ContentType', 'text');
+catalog = webread(url, options);
 
 % pull a list of netCDF files out of the catalog
-nc_all = regexp(catalog, '<a href=''([^>]+.nc)''>', 'tokens');
+nc_all = regexp(catalog, '<a href="([^>]+.nc)">', 'tokens');
 
 % cell elements are themselves cells, convert to cell array of character vectors
 nc_all = [nc_all{:}]';


### PR DESCRIPTION
Adjust the regex used to list files found in various THREDDS catalogs to explicitly use a `"` character. Previous version of the TDS used a `'` character.