### PR TITLE
Handling Empty Results

### DIFF
--- a/matlab/load_gc_thredds.m
+++ b/matlab/load_gc_thredds.m
@@ -65,6 +65,10 @@ options = weboptions("Timeout", 300);
 url = join([base_url dataset_id "/catalog.html"], "");
 files = ph.list_files(url, tag);
 nfiles = numel(files);      % determine number of files to download
+if nfiles == 0
+    data = [];  % no data to download
+    return
+end %if
 data = cell(nfiles, 1);     % pre-allocate a cell array for downloaded results
 
 % check to see if the user has the parallel processing toolbox and there are

--- a/matlab/utilities/process_files.m
+++ b/matlab/utilities/process_files.m
@@ -38,7 +38,7 @@ nc_files = string(nc_all(:));
 
 % check to see if we found any files to download, if not throw an error
 if size(nc_files, 1) == 0
-    error("Unable to find any files to download using %s at %s", [tag, url])
+    warning("Unable to find any files to download using tag '%s' from '%s'", tag, url)
 end %if
 end %function
 


### PR DESCRIPTION
Adds logic to the code to gracefully handle cases where the regex tag and/or dataset URL yields no files to download.